### PR TITLE
accept other port on connection with database

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -6,7 +6,12 @@ var Sequelize = require('sequelize');
 var basename  = path.basename(__filename);
 var db        = {};
 
-var sequelize = new Sequelize(CONFIG.db_name, CONFIG.db_user, CONFIG.db_password, {dialect:CONFIG.db_dialect, operatorsAliases:false});
+const sequelize = new Sequelize(CONFIG.db_name, CONFIG.db_user, CONFIG.db_password, {
+  host: CONFIG.db_host,
+  dialect: CONFIG.db_dialect,
+  port: CONFIG.db_port,
+  operatorsAliases: false
+});
 
 fs
   .readdirSync(__dirname)


### PR DESCRIPTION
When change the config.port on config.js file, the app dont take that and put 3306 instead of the port inside of config file. So this change give the correct port to sequelize.