### PR TITLE
Removed repeated res.setHeader() because res.json() already sets the proper headers

### DIFF
--- a/controllers/company.controller.js
+++ b/controllers/company.controller.js
@@ -2,7 +2,6 @@ const { Company } = require('../models');
 const { to, ReE, ReS } = require('../services/util.service');
 
 const create = async function(req, res){
-    res.setHeader('Content-Type', 'application/json');
     let err, company;
     let user = req.user;
 
@@ -25,7 +24,6 @@ const create = async function(req, res){
 module.exports.create = create;
 
 const getAll = async function(req, res){
-    res.setHeader('Content-Type', 'application/json');
     let user = req.user;
     let err, companies;
 
@@ -52,7 +50,6 @@ const getAll = async function(req, res){
 module.exports.getAll = getAll;
 
 const get = function(req, res){
-    res.setHeader('Content-Type', 'application/json');
     let company = req.company;
 
     return ReS(res, {company:company.toWeb()});

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -3,7 +3,6 @@ const authService       = require('../services/auth.service');
 const { to, ReE, ReS }  = require('../services/util.service');
 
 const create = async function(req, res){
-    res.setHeader('Content-Type', 'application/json');
     const body = req.body;
 
     if(!body.unique_key && !body.email && !body.phone){
@@ -22,7 +21,6 @@ const create = async function(req, res){
 module.exports.create = create;
 
 const get = async function(req, res){
-    res.setHeader('Content-Type', 'application/json');
     let user = req.user;
 
     return ReS(res, {user:user.toWeb()});


### PR DESCRIPTION
Just a simple cleanup to avoid the repeated repeated `res.setHeader('Content-Type', 'application/json');` since ReS/ReE are already using `res.json()` and it "sends a response (with the correct content-type)", according to the express docs: https://expressjs.com/en/api.html#res.json